### PR TITLE
Implemented `FilterCommand`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
-# Wrapper around `echo $input | command [--options] | cat`
+# Encapsulation of `echo $DATA | command [--options] [| command...]`
 
-Encapsulation of a command along with its options, provides a filter method.
+Encapsulation of a command along with its options which provides a filter method.
 Its primary role is to **facilitate filtering operations within a pipeline**,
 allowing for easy chaining and execution of executable filters.
+
+```php
+namespace PetrKnap\FilterCommand;
+
+# echo '<?php echo "Hello!";' | php
+$data = (new FilterCommand('php'))->filter('<?php echo "Hello!";');
+
+echo $data;
+```
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "allow-plugins": false,
     "sort-packages": true
   },
-  "description": "Wrapper around `echo $input | command [--options] | cat`",
+  "description": "Encapsulation of `echo $DATA | command [--options] [| command...]`",
   "funding": [
     {
       "type": "other",
@@ -26,7 +26,9 @@
   "license": "LGPL-3.0-or-later",
   "name": "petrknap/filter-command",
   "require": {
-    "php": ">=8.1"
+    "php": ">=8.1",
+    "petrknap/shorts": "^2.0|^3.0",
+    "symfony/process": "^4.0|^5.0|^6.0|^7.0"
   },
   "require-dev": {
     "nunomaduro/phpinsights": "^2.11",
@@ -35,15 +37,19 @@
     "phpunit/phpunit": "^10.5"
   },
   "scripts": {
-    "test": "echo ok",
+    "test": "@test-implementation",
     "check-implementation": [
+      "phpcs --colors --standard=PSR12 --exclude=Generic.Files.LineLength src tests",
+      "phpstan analyse --level max src --ansi --no-interaction",
+      "phpstan analyse --level 5 tests --ansi --no-interaction",
+      "phpinsights analyse src tests --ansi --no-interaction --format=github-action | sed -e \"s#::error file=$PWD/#::notice file=#g\""
     ],
     "check-requirements": [
       "composer update \"petrknap/*\"",
       "composer outdated \"petrknap/*\" --major-only --strict --ansi --no-interaction"
     ],
     "test-implementation": [
-      "@test"
+      "phpunit --colors=always --testdox tests"
     ],
     "ci-script": [
       "@check-implementation",

--- a/src/Exception/CouldNotFilterData.php
+++ b/src/Exception/CouldNotFilterData.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\FilterCommand\Exception;
+
+use PetrKnap\Shorts\Exception\CouldNotProcessData;
+
+/**
+ * @extends CouldNotProcessData<string>
+ */
+abstract class CouldNotFilterData extends CouldNotProcessData implements Exception
+{
+}

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\FilterCommand\Exception;
+
+use Throwable;
+
+/**
+ * @internal root exception
+ */
+interface Exception extends Throwable
+{
+}

--- a/src/FilterCommand.php
+++ b/src/FilterCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\FilterCommand;
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+final class FilterCommand
+{
+    /**
+     * @param non-empty-string $command
+     * @param array<non-empty-string> $options
+     */
+    public function __construct(
+        private readonly string $command,
+        private readonly array $options = [],
+    ) {
+    }
+
+    /**
+     * @throws Exception\CouldNotFilterData
+     */
+    public function filter(string $data): string
+    {
+        $process = new Process([
+            $this->command,
+            ...$this->options,
+        ]);
+        $process->setInput($data);
+        $process->run();
+        if (!$process->isSuccessful()) {
+            throw new class (__METHOD__, $data, new ProcessFailedException($process)) extends Exception\CouldNotFilterData {
+            };
+        }
+        return $process->getOutput();
+    }
+}

--- a/tests/FilterCommandTest.php
+++ b/tests/FilterCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\FilterCommand;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class FilterCommandTest extends TestCase
+{
+    public function testFiltersInputByCommand(): void
+    {
+        self::assertSame(
+            'test',
+            (new FilterCommand('php'))->filter('<?php echo "test";'),
+        );
+    }
+
+    #[DataProvider('dataThrows')]
+    public function testThrows(string $command, array $options, string $data): void
+    {
+        self::expectException(Exception\CouldNotFilterData::class);
+
+        (new FilterCommand($command, $options))->filter($data);
+    }
+
+    public static function dataThrows(): array
+    {
+        return [
+            'unknown command' => ['unknown', [], ''],
+            'unknown option' => ['php', ['--unknown'], ''],
+            'wrong data' => ['php', [], '<?php wrong data'],
+        ];
+    }
+}

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\FilterCommand;
+
+use PetrKnap\Shorts\PhpUnit\MarkdownFileTestInterface;
+use PetrKnap\Shorts\PhpUnit\MarkdownFileTestTrait;
+use PHPUnit\Framework\TestCase;
+
+final class ReadmeTest extends TestCase implements MarkdownFileTestInterface
+{
+    use MarkdownFileTestTrait;
+
+    public static function getPathToMarkdownFile(): string
+    {
+        return __DIR__ . '/../README.md';
+    }
+
+    public static function getExpectedOutputsOfPhpExamples(): iterable
+    {
+        return [
+            'example' => 'Hello!',
+        ];
+    }
+}


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the following code for me?
>> ```php
>> final class FilterCommand
>> {
>>     /**
>>      * @param non-empty-string $command
>>      * @param array<non-empty-string> $options
>>      */
>>     public function __construct(
>>         private readonly string $command,
>>         private readonly array $options = [],
>>     ) {/* ... */}
>> 
>>     /**
>>      * @throws Exception\FilterCommandCouldNotFilterData
>>      */
>>     public function filter(string $data): string {/* ... */}
>> }
>> ```
>
> Sure! Here's a brief summary of the code:
>
> The code defines a `final` class named `FilterCommand`. This class includes:
> 1. **Constructor**:
>    - Takes two parameters: a non-empty string `$command` and an array of non-empty strings `$options` (with an empty array as the default value).
>    - Initializes two private, readonly properties: `$command` and `$options`.
> 2. **Method**:
>    - A method named `filter` that takes a string `$data` as a parameter and returns a `string`.
>    - This method may throw an exception of type `Exception\FilterCommandCouldNotFilterData` if the filtering operation fails.
>
> In summary, `FilterCommand` is designed to perform a filtering operation using the specified command and options, while ensuring any issues during the operation are handled through exceptions.
>
>> Could you show me how to use it?
>
> Absolutely! Here's an example of how you can use the `FilterCommand` class to filter data using a specified command and options in a PHP script:
> ```php
> try {
>     // Create a new FilterCommand object with the desired command and options
>     $filterCommand = new FilterCommand('grep', ['pattern']);
> 
>     // Define the input data to be filtered
>     $inputData = "This is a line of input data.\nAnother line with pattern.\nMore data here.";
> 
>     // Apply the filter to the input data
>     $outputData = $filterCommand->filter($inputData);
> 
>     // Print the filtered output
>     echo "Filtered output: $outputData\n";
> } catch (Exception\FilterCommandCouldNotFilterData $e) {
>     // Handle any exceptions that occur during filtering
>     echo 'Error: ' . $e->getMessage();
> }
> ```
>
>> Is there any way to name something better?
>
> Let's fine-tune the naming for better clarity and readability:
> 1. **Class Name**: The class name `FilterCommand` is quite descriptive, but if you want to emphasize its function, consider something like `CommandFilter`.
> 2. **Property Names**:
>    - `$command` is straightforward, but if you want to be more explicit, you could use `$filterCommand`.
>    - `$options` is also clear, but `commandOptions` could be more descriptive.
> 3. **Method Name**: `filter` is quite apt. If you prefer something more descriptive, you could use `applyFilter` or `executeFilter`.
> 4. **Exception Name**: `FilterCommandCouldNotFilterData` is quite long and specific. A shorter, equally descriptive name could be `FilterFailedException`.
>
>> Is better argument name `$data` or `$input` for method `FilterCommand::filter()`?
> 
> Choosing between `$data` and `$input` depends on the context and what the method is doing with the argument. Here are some considerations for each:
>
> **Using `$data`**:
> - **Descriptive**: If the method is processing or manipulating the content, calling it `$data` can make it clear that it's dealing with a piece of information.
> - **Clarity**: It indicates that the argument is expected to be some form of data that will undergo transformation or filtering.
>
> **Using `$input`**:
> - **General**: If the method is expected to take various forms of input (e.g., text, numbers, streams), `$input` can be more flexible and general.
> - **Indicates Source**: It suggests that the argument is something being received to be processed, highlighting the method's role in handling incoming data.
>
> In the context of the filter method, where the method likely processes and transforms the input data, both `$data` and `$input` could be appropriate. However, if you want to emphasize that the method is processing raw information that will be filtered, `$data` might be slightly more descriptive.
> 
> In conclusion, both `$data` and `$input` are valid choices. If your method is more about transforming or processing the content, `$data` might be preferable. If it's about handling a variety of inputs, `$input` could be the better choice.
