### PR TITLE
Added support for pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ allowing for easy chaining and execution of executable filters.
 ```php
 namespace PetrKnap\ExternalFilter;
 
-# echo '<?php echo "Hello!";' | php
-$data = (new Filter('php'))->filter('<?php echo "Hello!";');
-
-echo $data;
+# echo "H4sIAAAAAAAAA0tJLEkEAGPz860EAAAA" | base64 --decode | gzip --decompress
+echo (
+    new Filter('base64', ['--decode'])
+)->pipe(
+    new Filter('gzip', ['--decompress'])
+)->filter('H4sIAAAAAAAAA0tJLEkEAGPz860EAAAA');
 ```
 
 ---

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class FilterTest extends TestCase
 {
-    public function testFilters(): void
+    public function testFiltersInput(): void
     {
         self::assertSame(
             'test',
@@ -17,12 +17,23 @@ final class FilterTest extends TestCase
         );
     }
 
+    public function testBuildsAndExecutesPipeline(): void
+    {
+        $pipeline = (new Filter('gzip'))->pipe(new Filter('base64'))->pipe(new Filter('base64', ['--decode']));
+        $filter = new Filter('gzip', ['--decompress']);
+
+        self::assertSame(
+            'test',
+            (new Filter('cat'))->pipe($pipeline)->pipe($filter)->filter('test'),
+        );
+    }
+
     #[DataProvider('dataThrows')]
-    public function testThrows(string $command, array $options, string $data): void
+    public function testThrows(string $command, array $options, string $input): void
     {
         self::expectException(Exception\FilterException::class);
 
-        (new Filter($command, $options))->filter($data);
+        (new Filter($command, $options))->filter($input);
     }
 
     public static function dataThrows(): array

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -20,7 +20,7 @@ final class ReadmeTest extends TestCase implements MarkdownFileTestInterface
     public static function getExpectedOutputsOfPhpExamples(): iterable
     {
         return [
-            'example' => 'Hello!',
+            'example' => 'data',
         ];
     }
 }


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the `pipe` method from the following code for me?
>> ```php
>> final class Filter
>> {
>>     public function __construct(
>>         private readonly string $command,
>>         private readonly array $options = [],
>>     ) {/* ... */}
>> 
>>     public function filter(string $input): string {/* ... */}
>> 
>>     public function pipe(self $to): self {/* ... */}
>> }
>> ```
>
> Absolutely! The `pipe` method in the `Filter` class is designed to facilitate the chaining of `Filter` objects. This method takes another `Filter` instance as its parameter and likely combines the current filter's operations with the operations of the provided `Filter` instance. The method returns the current `Filter` instance, allowing for a series of filters to be linked together in a pipeline. This is a common pattern in functional programming and stream processing to enhance readability and composability of code.
>
>> Could you show me how to use it?
>
> Sure! Here's an example of how you could use the `pipe` method in your `Filter` class:
> ```php
> $filter1 = new Filter('command1');
> $filter2 = new Filter('command2');
> 
> $combinedFilter = $filter1->pipe($filter2);
> 
> $result = $combinedFilter->filter('input string');
> echo $result;
> ```
>
> In this example, `filter1` and `filter2` are two instances of the `Filter` class. The `pipe` method is used to chain `filter1` and `filter2` together, creating a `combinedFilter`. Finally, the `filter` method is called on `combinedFilter` to process the input string. You can replace the placeholder implementations with the actual logic you need. This pattern allows you to apply multiple filters in a sequence, making your code modular and clean.
> 
>> Is there way to name the method `pipe` or its argument `$to` better?
> 
> You can certainly choose names that better reflect the functionality and improve readability. Here are some suggestions:
> 1. **For the method name**:
>    - `chainWith`
>    - `then`
>    - `appendFilter`
> 2. **For the argument name**:
>    - `$nextFilter`
>    - `$next`
>    - `$filterToAppend`
>
> Feel free to choose names that best fit your specific use case and coding style!
> 
>> What is more readable `$pipeline = $filter1->pipe(to: $filter2)` or `$chain = $filter1->chainWith(next: $filter2)`?
>
> Readability often depends on the context and the audience's familiarity with the terminology. However, here's a brief analysis of both options:
> 1. `$pipeline = $filter1->pipe(to: $filter2)`:
>    - **Pros**: The term "pipe" is often used in programming to indicate a flow or sequence of operations, which might be familiar to those with a background in Unix-style pipelines or functional programming.
>    - **Cons**: "Pipe" may not immediately suggest the chaining of filters to those unfamiliar with these concepts.
> 2. `$chain = $filter1->chainWith(next: $filter2)`:
>    - **Pros**: The term "chain" clearly indicates a series of linked operations. The argument name "next" intuitively suggests the progression to the next filter.
>    - **Cons**: It may be slightly more verbose but improves clarity for those not familiar with "pipe".
>
> If clarity for a broader audience is a priority, `$chain = $filter1->chainWith(next: $filter2)` may be more readable. If the audience is familiar with functional programming concepts, `$pipeline = $filter1->pipe(to: $filter2)` could work just as well. Ultimately, it's a matter of preference and context. Choose the naming convention that best fits your team's style and project requirements.