### PR TITLE
Added support for output and error streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ echo (
 )->filter('H4sIAAAAAAAAA0tJLEkEAGPz860EAAAA');
 ```
 
+If you want to process external data, redirect output or get errors, you can use input, output or error streams.
+
+```php
+namespace PetrKnap\ExternalFilter;
+
+$errorStream = fopen('php://memory', 'w+');
+
+(new Filter('php'))->filter(
+    '<?php fwrite(fopen("php://stderr", "w"), "error");',
+    error: $errorStream,
+);
+
+rewind($errorStream);
+echo stream_get_contents($errorStream);
+fclose($errorStream);
+```
+
 ---
 
 Run `composer require petrknap/external-filter` to install it.

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -24,25 +24,41 @@ final class Filter
 
     /**
      * @param string|resource $input
+     * @param resource|null $output
+     * @param resource|null $error
+     *
+     * @return ($output is null ? string : null)
      *
      * @throws Exception\FilterException
      */
-    public function filter(mixed $input): string
+    public function filter(mixed $input, mixed $output = null, mixed $error = null): string|null
     {
         if (!is_string($input) && !is_resource($input)) {
             throw new class ('$input must be string|resource') extends InvalidArgumentException implements Exception\FilterException {
             };
         }
+        if ($output !== null && !is_resource($output)) {
+            throw new class ('$output must be resource|null') extends InvalidArgumentException implements Exception\FilterException {
+            };
+        }
+        if ($error !== null && !is_resource($error)) {
+            throw new class ('$error must be resource|null') extends InvalidArgumentException implements Exception\FilterException {
+            };
+        }
 
-        $process = $this->startFilter($input);
-
+        $process = $this->startFilter($input, static function (string $type, string $data) use ($output, $error): void {
+            /** @var Process::OUT|Process::ERR $type */
+            match ($type) {
+                Process::OUT => $output === null or fwrite($output, $data),
+                Process::ERR => $error === null or fwrite($error, $data),
+            };
+        });
         $process->wait();
         if (!$process->isSuccessful()) {
             throw new class ($process) extends ProcessFailedException implements Exception\FilterException {
             };
         }
-
-        return $process->getOutput();
+        return $output === null ? $process->getOutput() : null;
     }
 
     public function pipe(self $to): self
@@ -67,10 +83,10 @@ final class Filter
     /**
      * @param string|resource $input
      */
-    private function startFilter(mixed $input): Process
+    private function startFilter(mixed $input, callable|null $callback): Process
     {
         if ($this->previous !== null) {
-            $input = $this->previous->startFilter($input);
+            $input = $this->previous->startFilter($input, null);
         }
 
         $process = new Process([
@@ -78,7 +94,7 @@ final class Filter
             ...$this->options,
         ]);
         $process->setInput($input);
-        $process->start();
+        $process->start($callback);
 
         return $process;
     }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -36,6 +36,41 @@ final class FilterTest extends TestCase
         yield 'resource(in-memory stream)' => [$inMemoryStream, $helloWorldPhpStdOut];
     }
 
+    #[DataProvider('dataWritesToStreamsAndReturnsExpectedValue')]
+    public function testWritesToStreamsAndReturnsExpectedValue(bool $useOutput, bool $useError): void
+    {
+        $outputStream = fopen('php://memory', 'w+');
+        $errorStream = fopen('php://memory', 'w+');
+
+        $returned = (new Filter('php'))->filter(
+            input: '<?php fwrite(fopen("php://stdout", "w"), "output"); fwrite(fopen("php://stderr", "w"), "error");',
+            output: $useOutput ? $outputStream : null,
+            error: $useError ? $errorStream : null,
+        );
+        rewind($outputStream);
+        rewind($errorStream);
+
+        self::assertSame([
+            'returned' => $useOutput ? null : 'output',
+            'output' => $useOutput ? 'output' : '',
+            'error' => $useError ? 'error' : '',
+        ], [
+            'returned' => $returned,
+            'output' => stream_get_contents($outputStream),
+            'error' => stream_get_contents($errorStream),
+        ]);
+    }
+
+    public static function dataWritesToStreamsAndReturnsExpectedValue(): array
+    {
+        return [
+            'no stream' => [false, false],
+            'output stream' => [true, false],
+            'error stream' => [false, true],
+            'both streams' => [true, true],
+        ];
+    }
+
     public function testBuildsAndExecutesPipeline(): void
     {
         $pipeline = (new Filter('gzip'))->pipe(new Filter('base64'))->pipe(new Filter('base64', ['--decode']));
@@ -48,20 +83,27 @@ final class FilterTest extends TestCase
     }
 
     #[DataProvider('dataThrows')]
-    public function testThrows(string $command, array $options, mixed $input): void
+    public function testThrows(string $command, array $options, mixed $input, mixed $output, mixed $error): void
     {
         self::expectException(Exception\FilterException::class);
 
-        (new Filter($command, $options))->filter($input);
+        (new Filter($command, $options))->filter($input, $output, $error);
     }
 
     public static function dataThrows(): array
     {
+        $closedStream = fopen('php://memory', 'w');
+        fclose($closedStream);
         return [
-            'unknown command' => ['unknown', [], ''],
-            'unknown option' => ['php', ['--unknown'], ''],
-            'wrong data' => ['php', [], '<?php wrong data'],
-            'unsupported input' => ['php', [], new stdClass()],
+            'unknown command' => ['unknown', [], '', null, null],
+            'unknown option' => ['php', ['--unknown'], '', null, null],
+            'wrong data' => ['php', [], '<?php wrong data', null, null],
+            'unsupported input' => ['php', [], new stdClass(), null, null],
+            'unsupported output' => ['php', [], '', new stdClass(), null],
+            'unsupported error' => ['php', [], '', null, new stdClass()],
+            'closed input' => ['php', [], $closedStream, null, null],
+            'closed output' => ['php', [], '', $closedStream, null],
+            'closed error' => ['php', [], '', null, $closedStream],
         ];
     }
 }

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -20,7 +20,8 @@ final class ReadmeTest extends TestCase implements MarkdownFileTestInterface
     public static function getExpectedOutputsOfPhpExamples(): iterable
     {
         return [
-            'example' => 'data',
+            'pipeline' => 'data',
+            'error-stream' => 'error',
         ];
     }
 }


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the `filter` methods `$output` and `$error` params from the following code for me?
>> ```php
>> final class Filter
>> {
>>     public function __construct(
>>         private readonly string $command,
>>         private readonly array $options = [],
>>     ) {}
>> 
>>     /**
>>      * @param string|resource $input
>>      * @param resource|null $output
>>      * @param resource|null $error
>>      *
>>      * @return ($output is null ? string : null)
>>      *
>>      * @throws Exception\FilterException
>>      */
>>     public function filter(mixed $input): string|null {/* ... */}
>> 
>>     public function pipe(self $to): self {/* ... */}
>> }
>> ```
>
> In the `filter` method of the `Filter` class, the `$output` and `$error` parameters are used to manage the results of the filtering operation.
>
> **`$output` Parameter**
> - **Type**: `resource|null`
> - **Purpose**: This parameter can be used to provide a stream resource (like a file handle or a memory stream) where the output of the filter operation will be written. If `$output` is `null`, the method returns a string containing the result of the filter operation.
>
> **`$error` Parameter**
> - **Type**: `resource|null`
> - **Purpose**: This parameter can be used to provide a stream resource where any error messages or logs related to the filtering operation will be written. If no resource is provided, error handling is managed differently within the method.
>
> **Return Value**
> - If `$output` is `null`, the method returns the filtered result as a string.
> - If `$output` is provided (i.e., not `null`), the method writes the filtered result to the specified resource and returns `null`.
>
> **Summary**: The `$output` and `$error` parameters allow the method to be flexible in terms of where it writes its results and errors, either to streams or as return values. This design enables better control over output and error handling, making the `filter` method adaptable for different use cases.
>
>> Could you show me how to use it?
>
> Certainly! Here's an example showing how to use the `filter` method with the `$output` and `$error` parameters:
> ```php
> // Open a memory stream for output
> $outputStream = fopen('php://memory', 'w+');
> // Open a memory stream for error handling (optional)
> $errorStream = fopen('php://memory', 'w+');
> 
> // Create a filter instance
> $filter = new Filter('exampleCommand');
> 
> // Use the filter method with a string input and output to a memory stream
> $inputString = "Input data";
> $filter->filter($inputString, $outputStream, $errorStream);
> 
> // Rewind and read the output stream content
> rewind($outputStream);
> $outputData = stream_get_contents($outputStream);
> echo "Output: " . $outputData . PHP_EOL;
> 
> // Rewind and read the error stream content (if any)
> rewind($errorStream);
> $errorData = stream_get_contents($errorStream);
> echo "Error: " . $errorData . PHP_EOL;
> 
> // Close the streams
> fclose($outputStream);
> fclose($errorStream);
> ```
>
>> Is there any way to name the parameters better?
>
> Sure! Here are some suggestions to improve the clarity of your parameter names:
>
> **For `$input`**:
> - `$data`
> - `$content`
> - `$inputData`
>
> **For `$output`**:
> - `$outputStream`
> - `$destinationStream`
> - `$resultStream`
>
> **For `$error`**:
> - `$errorStream`
> - `$errorLog`
> - `$errorOutput`
>
> These new names aim to be more descriptive, making it clearer what each parameter represents. Choose the ones that best fit the context of your application and make your code more readable.