### PR TITLE
Added PHP factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Its primary role is to **facilitate filtering operations within a pipeline**,
 allowing for easy chaining and execution of executable filters.
 
 ```php
-namespace PetrKnap\ExternalFilter;
+use PetrKnap\ExternalFilter\Filter;
 
 # echo "H4sIAAAAAAAAA0tJLEkEAGPz860EAAAA" | base64 --decode | gzip --decompress
 echo Filter::new('base64', ['--decode'])
@@ -16,7 +16,7 @@ echo Filter::new('base64', ['--decode'])
 If you want to process external data, redirect output or get errors, you can use input, output or error streams.
 
 ```php
-namespace PetrKnap\ExternalFilter;
+use PetrKnap\ExternalFilter\Filter;
 
 $errorStream = fopen('php://memory', 'w+');
 
@@ -28,6 +28,15 @@ Filter::new('php')->filter(
 rewind($errorStream);
 echo stream_get_contents($errorStream);
 fclose($errorStream);
+```
+
+If you want to call PHP code in the pipeline, you can via factory.
+
+```php
+use PetrKnap\ExternalFilter\Filter;
+
+echo Filter::new(phpSnippet: 'echo stream_get_contents(STDIN);')
+    ->filter(b'data');
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you want to call PHP code in the pipeline, you can via factory.
 ```php
 use PetrKnap\ExternalFilter\Filter;
 
-echo Filter::new(phpSnippet: 'echo stream_get_contents(STDIN);')
+echo Filter::new(phpSnippet: 'fputs(STDOUT, fgets(STDIN));')
     ->filter(b'data');
 ```
 

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -13,15 +13,11 @@ final class FilterTest extends TestCase
     private const INPUT = b'input';
 
     #[DataProvider('dataFactoryWorks')]
-    public function testFactoryWorks(array $arguments): void
+    public function testFactoryWorks(array $factoryArguments): void
     {
-        $filter = Filter::new(...$arguments);
+        $filter = Filter::new(...$factoryArguments);
 
-        self::assertInstanceOf(
-            Filter::class,
-            $filter,
-        );
-
+        self::assertInstanceOf(Filter::class, $filter);
         self::assertSame(self::INPUT, $filter->filter(self::INPUT));
     }
 
@@ -29,6 +25,7 @@ final class FilterTest extends TestCase
     {
         return [
             'command' => [['command' => 'cat']],
+            'command with options' => [['command' => 'cat', 'options' => ['--show-nonprinting']]],
             'PHP file' => [['phpFile' => __DIR__ . '/Some/filter.php']],
             'PHP snippet' => [['phpSnippet' => 'fputs(STDOUT, fgets(STDIN));']],
             'PHP snippet (prefixed)' => [['phpSnippet' => '<?php fputs(STDOUT, fgets(STDIN));']],
@@ -46,10 +43,10 @@ final class FilterTest extends TestCase
     public static function dataFactoryThrowsOnBadMethodCall(): array
     {
         return [
-            'command + extra' => [['command' => 'cat', 'phpFile' => __FILE__]],
-            'command + options + extra' => [['command' => 'cat', 'options' => [], 'phpFile' => __FILE__]],
-            'phpFile + extra' => [['phpFile' => __FILE__, 'options' => []]],
-            'phpSnippet + extra' => [['phpSnippet' => 'echo "a";', 'options' => []]],
+            'command with extra' => [['command' => 'cat', 'phpFile' => __FILE__]],
+            'command with options and extra' => [['command' => 'cat', 'options' => ['--show-nonprinting'], 'phpFile' => __FILE__]],
+            'PHP file with extra' => [['phpFile' => __FILE__, 'options' => []]],
+            'PHP snippet with extra' => [['phpSnippet' => 'echo "a";', 'options' => []]],
         ];
     }
 }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -4,15 +4,52 @@ declare(strict_types=1);
 
 namespace PetrKnap\ExternalFilter;
 
+use BadMethodCallException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class FilterTest extends TestCase
 {
-    public function testFactoryWorks()
+    private const INPUT = b'input';
+
+    #[DataProvider('dataFactoryWorks')]
+    public function testFactoryWorks(array $arguments): void
     {
+        $filter = Filter::new(...$arguments);
+
         self::assertInstanceOf(
             Filter::class,
-            Filter::new(command: 'php'),
+            $filter,
         );
+
+        self::assertSame(self::INPUT, $filter->filter(self::INPUT));
+    }
+
+    public static function dataFactoryWorks(): array
+    {
+        return [
+            'command' => [['command' => 'cat']],
+            'PHP file' => [['phpFile' => __DIR__ . '/Some/filter.php']],
+            'PHP snippet' => [['phpSnippet' => 'fputs(STDOUT, fgets(STDIN));']],
+            'PHP snippet (prefixed)' => [['phpSnippet' => '<?php fputs(STDOUT, fgets(STDIN));']],
+        ];
+    }
+
+    #[DataProvider('dataFactoryThrowsOnBadMethodCall')]
+    public function testFactoryThrowsOnBadMethodCall(array $factoryArguments): void
+    {
+        self::expectException(BadMethodCallException::class);
+
+        Filter::new(...$factoryArguments);
+    }
+
+    public static function dataFactoryThrowsOnBadMethodCall(): array
+    {
+        return [
+            'command + extra' => [['command' => 'cat', 'phpFile' => __FILE__]],
+            'command + options + extra' => [['command' => 'cat', 'options' => [], 'phpFile' => __FILE__]],
+            'phpFile + extra' => [['phpFile' => __FILE__, 'options' => []]],
+            'phpSnippet + extra' => [['phpSnippet' => 'echo "a";', 'options' => []]],
+        ];
     }
 }

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -22,6 +22,7 @@ final class ReadmeTest extends TestCase implements MarkdownFileTestInterface
         return [
             'pipeline' => 'data',
             'error-stream' => 'error',
+            'filter-factory' => 'data',
         ];
     }
 }

--- a/tests/Some/filter.php
+++ b/tests/Some/filter.php
@@ -1,0 +1,6 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+echo stream_get_contents(STDIN);

--- a/tests/Some/filter.php
+++ b/tests/Some/filter.php
@@ -3,4 +3,4 @@
 
 declare(strict_types=1);
 
-echo stream_get_contents(STDIN);
+fputs(STDOUT, fgets(STDIN));


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the following code for me?
>> ```php
>> trait FilterFactory {
>>     /**
>>      * @param non-empty-string|null $code code which consumes {@see STDIN}
>>      * @param non-empty-string|null $file file which consumes {@see STDIN}
>>      */
>>     public static function php(string|null $code = null, string|null $file = null): Filter {/*...*/}
>> }
>> ```
>
> Absolutely! Here's a brief summary of your code:
>
> The `FilterFactory` trait includes a static method `php`, which creates a `Filter` object. This method accepts two optional parameters, `code` and `file`, which are either non-empty strings or null. Both parameters are intended to consume standard input (`STDIN`).
>
> Do you need any further explanation or details?
>
>> Could you show me how to use it?
>
> Sure thing! Here's a simple example of how you might use the FilterFactory trait in a PHP script:
> ```php
> $filter = FilterFactory::php('<?php echo "Hello, World!"; ?>', 'example.php');
> $filter->execute();
> ```
>
>> Is there any way to do name the method or its arguments better as the arguments are exclusive?
>
> Great point! It’s definitely a good idea to make the method name and its arguments more intuitive, especially when the arguments are mutually exclusive. Here’s one way to make it clearer by splitting the method into two different methods:
> ```php
> trait FilterFactory {
>     /**
>      * Create a Filter from a code string.
>      *
>      * @param non-empty-string $code code which consumes {@see STDIN}
>      */
>     public static function fromCode(string $code): Filter {
>         return new Filter($code, null);
>     }
> 
>     /**
>      * Create a Filter from a file path.
>      *
>      * @param non-empty-string $file file which consumes {@see STDIN}
>      */
>     public static function fromFile(string $file): Filter {
>         return new Filter(null, $file);
>     }
> }
> ```
> 
> By splitting the method into `fromCode` and `fromFile`, we make it clear which parameter to use and avoid confusion since the parameters are mutually exclusive. This way, the method names are self-explanatory, and it's easier to use the `FilterFactory` methods.
> 
> Does this approach align with what you were thinking?